### PR TITLE
Fix CodeEditor not loading when WordPress is installed in a subfolder…

### DIFF
--- a/components/code-editor/editor.js
+++ b/components/code-editor/editor.js
@@ -104,7 +104,7 @@ class CodeEditor extends Component {
 	}
 
 	render() {
-		return <textarea ref={ ( ref ) => ( this.textarea = ref ) } value={ this.props.value } />;
+		return <textarea ref={ ( ref ) => ( this.textarea = ref ) } defaultValue={ this.props.value } />;
 	}
 }
 

--- a/components/code-editor/index.js
+++ b/components/code-editor/index.js
@@ -21,7 +21,7 @@ function loadScript() {
 		}
 
 		const script = document.createElement( 'script' );
-		script.src = `/wp-admin/load-scripts.php?load=${ handles.join( ',' ) }`;
+		script.src = `${ wpApiSettings.schema.url }/wp-admin/load-scripts.php?load=${ handles.join( ',' ) }`;
 		script.onload = resolve;
 		script.onerror = reject;
 
@@ -35,7 +35,7 @@ function loadStyle() {
 
 		const style = document.createElement( 'link' );
 		style.rel = 'stylesheet';
-		style.href = `/wp-admin/load-styles.php?load=${ handles.join( ',' ) }`;
+		style.href = `${ wpApiSettings.schema.url }/wp-admin/load-styles.php?load=${ handles.join( ',' ) }`;
 		style.onload = resolve;
 		style.onerror = reject;
 

--- a/components/code-editor/test/__snapshots__/editor.js.snap
+++ b/components/code-editor/test/__snapshots__/editor.js.snap
@@ -2,6 +2,6 @@
 
 exports[`CodeEditor should render without an error 1`] = `
 <textarea
-  value="<b>wowee</b>"
+  defaultValue="<b>wowee</b>"
 />
 `;


### PR DESCRIPTION
… (#6777)

* Add translators note

* Fix warning & subfolder issue

* Revert changes to onBlur

* Use defaultValue instead of value

* Update snapshots

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
